### PR TITLE
Changed shuffling algorithm in model initialization because of mono

### DIFF
--- a/fasttext.fsx
+++ b/fasttext.fsx
@@ -4,7 +4,7 @@
 open NFastText
 open NFastText.FileReader
 
-let rootPath = "d:/ft"
+let rootPath = __SOURCE_DIRECTORY__
 
 let testClassifier()=
     //run load_test_data.sh before this script

--- a/load_test_data.sh
+++ b/load_test_data.sh
@@ -33,3 +33,6 @@ then
     wget -c http://www-nlp.stanford.edu/~lmthang/morphoNLM/rw.zip -P "${DATADIR}"
     unzip "${DATADIR}/rw.zip" -d "${DATADIR}"
 fi
+
+cut -f 1,2 "${DATADIR}"/rw/rw.txt | awk '{print tolower($0)}' | tr '\t' '\n' > "${DATADIR}"/queries.txt
+

--- a/src/NFastText/Model.fs
+++ b/src/NFastText/Model.fs
@@ -179,7 +179,14 @@ module ModelImplementations =
             let c = float32(System.Math.Sqrt(float(counts.[i])))
             for j = 0 to int(c * float32(negativeTableSize) / z) - 1 do
                 negatives.Add(i)
-        negatives.Sort(fun x y -> rng.Next())
+        // randomly shuffle the array
+        let swap (a: ResizeArray<int>) x y =
+            let tmp = a.[x]
+            a.[x] <- a.[y]
+            a.[y] <- tmp        
+        for i = 0 to negatives.Count-1 do
+            swap negatives i (rng.DiscrUniformSample(i, negatives.Count-1)) 
+
         negatives
 
     type NegativeSamplingModel(negatives : ResizeArray<int>, neg, model : ModelState) =


### PR DESCRIPTION
I was running the code on mono and ran into issues with `ResizeArray`. 

The original code was using the `Sort` method with random comparisons. Unfortunately this part of the code didn't terminate even after a few hours. It seems that mono uses a different algorithm for sorting than .NET. I changed the shuffling algorithm and everything works fine. 

I also did some minor fixes in downloading of the test data (`queries.txt` were not downloaded) and in the test script.